### PR TITLE
Added `lockWidget` and 'onTapLockedItem'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## [1.3.2] - 2025-11-30
+### Added
+- feat: Added `lockWidget` to `AvatarMakerCustomizer` to allow custom widgets for locked items.
+- feat: Added `onTapLockedItem` callback to `AvatarMakerCustomizer` to handle taps on locked items.
+- docs: Updated documentation for item locking.
+- example: Updated example app to demonstrate custom lock UI and interaction.
+
 ## [1.3.1] - 29/11/2025
 ### Fixed
 - fix: Example application

--- a/doc/how-to/lock_items.md
+++ b/doc/how-to/lock_items.md
@@ -1,15 +1,9 @@
-# How to lock items ?
-
-**Summary:**
-This commit introduces the ability to lock avatar customization items based on specific conditions (e.g., user level, premium membership, etc.).
-
-**Changes Made:**
-
-1.  **`AvatarMakerCustomizer` Update (`lib/src/customizer/avatar_maker_customizer.dart`):**
     *   A new optional parameter named `isItemLocked` was added to the `AvatarMakerCustomizer` widget.
     *   **Signature:** `bool Function(PropertyCategoryIds categoryId, String itemId)? isItemLocked`
     *   **Functionality:** This callback function is invoked for each customization item. If it returns `true`, the item is considered locked; if `false`, it is unlocked.
-    *   This parameter is passed down to the `CustomizerBody` widget to handle locked items in the UI.
+    *   **New Parameters:**
+        *   `Widget? lockWidget`: A custom widget to display overlaying the item when it is locked. Defaults to a semi-transparent black overlay with a lock icon.
+        *   `Function(PropertyCategoryIds, String)? onTapLockedItem`: A callback triggered when a user taps on a locked item. This is useful for showing "Unlock" dialogs or premium upgrade prompts.
 
 2.  **Example Application (`example/lib/main.dart`):**
     *   A "User Level" slider was added to the example application.
@@ -17,6 +11,9 @@ This commit introduces the ability to lock avatar customization items based on s
         *   If the category is `Accessory` and the item name contains "Glasses":
         *   If the user level is less than 5, these items are marked as **locked** (`true`).
         *   If the level is 5 or higher, the items become **unlocked** (`false`).
+    *   **Custom Lock UI & Interaction:**
+        *   A custom red lock overlay is provided via `lockWidget`.
+        *   Tapping a locked item shows a dialog explaining why it's locked and offering an "Unlock" action (simulated).
 
 This structure allows for a dynamic locking mechanism to be established via an externally provided function, without embedding specific business logic into the core package.
 
@@ -24,7 +21,7 @@ This structure allows for a dynamic locking mechanism to be established via an e
 
 ## Usage Example
 
-Here's how to implement the `isItemLocked` feature in your application:
+Here's how to implement the `isItemLocked` feature with custom UI and interaction:
 
 ```dart
 class _MyPageState extends State<MyPage> {
@@ -53,14 +50,40 @@ class _MyPageState extends State<MyPage> {
           // Avatar Customizer with Lock Logic
           AvatarMakerCustomizer(
             controller: myController,
+            
+            // 1. Define Locking Logic
             isItemLocked: (category, item) {
-              // Lock glasses if user level is below 5
               if (category == PropertyCategoryIds.Accessory && 
                   item.contains("Glasses")) {
                 return _userLevel < 5;
               }
-              // All other items are unlocked
               return false;
+            },
+            
+            // 2. (Optional) Custom Lock Overlay
+            lockWidget: Container(
+              color: Colors.red.withOpacity(0.5),
+              child: Icon(Icons.lock, color: Colors.white),
+            ),
+            
+            // 3. (Optional) Handle Taps on Locked Items
+            onTapLockedItem: (category, item) {
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: Text("Locked!"),
+                  content: Text("You need Level 5 to use this item."),
+                  actions: [
+                    TextButton(
+                      onPressed: () {
+                         // Implement unlock logic (e.g., deduct gold)
+                         Navigator.pop(context);
+                      }, 
+                      child: Text("Unlock")
+                    ),
+                  ],
+                ),
+              );
             },
           ),
         ],
@@ -71,9 +94,7 @@ class _MyPageState extends State<MyPage> {
 ```
 
 ### Key Points:
-- The `isItemLocked` callback receives two parameters:
-    - `category`: The `PropertyCategoryIds` enum value (e.g., `Accessory`, `Hair`, `Clothes`)
-    - `item`: The item identifier string (e.g., "Glasses", "Hat")
-- Return `true` to lock the item, `false` to unlock it
-- You can implement any business logic: level checks, premium status, achievements, etc.
-- The UI will automatically display locked items with appropriate visual indicators
+- **`isItemLocked`**: Determines if an item is locked.
+- **`lockWidget`**: Customizes the visual appearance of locked items.
+- **`onTapLockedItem`**: Handles user interaction with locked items (e.g., upsell, requirements).
+- You can implement any business logic: level checks, premium status, achievements, in-game currency, etc.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -195,6 +195,46 @@ class _NewPageState extends State<NewPage> {
                     }
                     return false;
                   },
+                  lockWidget: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.red.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Center(
+                      child: Icon(
+                        Icons.lock_outline,
+                        color: Colors.white,
+                        size: 40,
+                      ),
+                    ),
+                  ),
+                  onTapLockedItem: (category, item) {
+                    showDialog(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: Text("Item Locked"),
+                        content: Text(
+                            "You need to reach Level 5 to unlock this item!"),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: Text("OK"),
+                          ),
+                          TextButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                              // Simulate unlocking or buying
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                    content: Text("Unlock logic goes here...")),
+                              );
+                            },
+                            child: Text("Unlock Now (50 Gold)"),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
                 ),
               ),
             ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -376,10 +376,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -629,10 +629,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/customizer/avatar_maker_customizer.dart
+++ b/lib/src/customizer/avatar_maker_customizer.dart
@@ -45,6 +45,15 @@ class AvatarMakerCustomizer extends StatefulWidget {
   final bool Function(PropertyCategoryIds categoryId, String itemId)?
       isItemLocked;
 
+  /// Widget to display when an item is locked.
+  /// If not provided, a default lock icon will be shown.
+  final Widget? lockWidget;
+
+  /// Callback to be called when a locked item is tapped.
+  /// This can be used to show a dialog to unlock the item, etc.
+  final void Function(PropertyCategoryIds categoryId, String itemId)?
+      onTapLockedItem;
+
   /// The [AvatarMakerController] to use for saving the avatar.
   ///
   /// If not provided, it will be fetched from Provider or a new controller will be created.
@@ -71,6 +80,8 @@ class AvatarMakerCustomizer extends StatefulWidget {
     this.autosave = false,
     this.onChange,
     this.isItemLocked,
+    this.lockWidget,
+    this.onTapLockedItem,
     this.controller,
   })  : this.theme = theme ?? AvatarMakerThemeData.defaultTheme,
         super(key: key);
@@ -187,6 +198,8 @@ class _AvatarMakerCustomizerState extends State<AvatarMakerCustomizer>
           onTapOption: onTapOption,
           onArrowTap: onArrowTap,
           isItemLocked: widget.isItemLocked,
+          lockWidget: widget.lockWidget,
+          onTapLockedItem: widget.onTapLockedItem,
         ),
       ),
     );

--- a/lib/src/customizer/widgets/customizer_body.dart
+++ b/lib/src/customizer/widgets/customizer_body.dart
@@ -16,6 +16,9 @@ class CustomizerBody extends StatelessWidget {
   final void Function(bool isLeft) onArrowTap;
   final bool Function(PropertyCategoryIds categoryId, String itemId)?
       isItemLocked;
+  final Widget? lockWidget;
+  final void Function(PropertyCategoryIds categoryId, String itemId)?
+      onTapLockedItem;
 
   const CustomizerBody({
     required this.avatarMakerController,
@@ -25,6 +28,8 @@ class CustomizerBody extends StatelessWidget {
     required this.onTapOption,
     required this.onArrowTap,
     this.isItemLocked,
+    this.lockWidget,
+    this.onTapLockedItem,
   });
 
   @override
@@ -60,8 +65,9 @@ class CustomizerBody extends StatelessWidget {
               isItemLocked?.call(propertyCategory.id, item.id) ?? false;
 
           return InkWell(
-            onTap:
-                isLocked ? null : () => onTapOption(item, propertyCategory.id),
+            onTap: isLocked
+                ? () => onTapLockedItem?.call(propertyCategory.id, item.id)
+                : () => onTapOption(item, propertyCategory.id),
             child: Stack(
               children: [
                 Container(
@@ -83,19 +89,20 @@ class CustomizerBody extends StatelessWidget {
                   ),
                 ),
                 if (isLocked)
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.3),
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: Center(
-                      child: Icon(
-                        Icons.lock,
-                        color: Colors.white,
-                        size: 60,
+                  lockWidget ??
+                      Container(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.3),
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Center(
+                          child: Icon(
+                            Icons.lock,
+                            color: Colors.white,
+                            size: 60,
+                          ),
+                        ),
                       ),
-                    ),
-                  ),
               ],
             ),
           );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -425,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -702,10 +702,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:

--- a/test/src/customizer/avatar_maker_customizer_test.dart
+++ b/test/src/customizer/avatar_maker_customizer_test.dart
@@ -145,4 +145,75 @@ void main() {
       );
     });
   });
+
+  group('Custom Lock Widget and Callback', () {
+    testWidgets('lockWidget should be displayed for locked items',
+        (WidgetTester tester) async {
+      final controller = NonPersistentAvatarMakerController();
+
+      // Lock everything
+      bool isLocked(PropertyCategoryIds category, String itemId) => true;
+
+      final customLockIcon = Key('customLockIcon');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AvatarMakerCustomizer(
+              controller: controller,
+              isItemLocked: isLocked,
+              lockWidget: Container(
+                key: customLockIcon,
+                child: Icon(Icons.lock_clock),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Should find our custom widget
+      expect(find.byKey(customLockIcon), findsWidgets);
+      // Should NOT find the default lock icon (unless it's the same icon, but we used lock_clock)
+      expect(find.byIcon(Icons.lock), findsNothing);
+    });
+
+    testWidgets('onTapLockedItem should be called when tapping a locked item',
+        (WidgetTester tester) async {
+      final controller = NonPersistentAvatarMakerController();
+
+      // Lock everything
+      bool isLocked(PropertyCategoryIds category, String itemId) => true;
+
+      bool tapCallbackCalled = false;
+      void onTapLocked(PropertyCategoryIds category, String itemId) {
+        tapCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AvatarMakerCustomizer(
+              controller: controller,
+              isItemLocked: isLocked,
+              onTapLockedItem: onTapLocked,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Find any locked item (they are all locked) and tap it
+      // We need to find a tappable area. The InkWell is inside the GridView.
+      // Let's find the first item in the grid.
+      final firstItem = find.byType(InkWell).first;
+      await tester.tap(firstItem);
+      await tester.pump();
+
+      expect(tapCallbackCalled, isTrue,
+          reason: "onTapLockedItem should be called");
+    });
+  });
 }


### PR DESCRIPTION
- feat: Added `lockWidget` to `AvatarMakerCustomizer` to allow custom widgets for locked items.
- feat: Added `onTapLockedItem` callback to `AvatarMakerCustomizer` to handle taps on locked items.
- docs: Updated documentation for item locking.
- example: Updated example app to demonstrate custom lock UI and interaction.
